### PR TITLE
Polipo proxy server configuration

### DIFF
--- a/polipo/config
+++ b/polipo/config
@@ -1,0 +1,44 @@
+daemonise=false
+diskCacheRoot=/var/cache/polipo/
+
+proxyAddress=127.0.0.1
+proxyName=localhost
+allowedClients=127.0.0.1
+cacheIsShared=false
+
+serverSlots=4
+serverSlots1=4
+serverMaxSlots=8
+maxConnectionAge=5m
+
+pipelineAdditionalRequests=maybe
+smallRequestTime=60s
+
+disableLocalInterface=false
+disableConfiguration=false
+disableIndexing=false
+disableServersList=false
+
+relaxTransparency=maybe
+mindlesslyCacheVary=true
+dontCacheRedirects=true
+
+dnsGethostbynameTtl=0
+dnsNegativeTtl=0
+dnsUseGethostbyname=happily
+
+diskCacheUnlinkTime=60d
+diskCacheTruncateTime=7d
+diskCacheTruncateSize=10485760 # 10 MB
+diskCacheWriteoutOnClose=1048576 # 1 MB
+
+maxAge=1d
+maxNoModifiedAge=1d
+maxExpiresAge=60d
+
+# The following option is not described properly in the documentation
+# I guess it means fraction of the time between today and the time when it was last modified.
+# So, if a document was last modified 10 days from today, it would be present in the cache for 10 days
+# if the object has no Expires header.
+
+maxAgeFraction=1


### PR DESCRIPTION
Polipo is a lightweight proxy server that can be used to cache all HTTP requests. It can operate in private as well as public mode.

Some Personal Use Cases: 
- Share a cache across multiple browsers, say chrome and firefox?
- Save extra bandwidth required when your browser crashes and marks all cache as invalid.
- Don't cache anything at browser level because it makes the browser more snappy.

More about polipo can be found at http://www.pps.univ-paris-diderot.fr/~jch/software/polipo/polipo.html
